### PR TITLE
feat: Add min/max params for edgex-dto-duration tag

### DIFF
--- a/common/validator.go
+++ b/common/validator.go
@@ -104,9 +104,42 @@ func getErrorMessage(e validator.FieldError) string {
 }
 
 // ValidateDuration validate field which should follow the ISO 8601 Durations format
+// the min/max of the Duration can be set via the tag params
+// ex. edgex-dto-duration=10ms0x2C24h - 10ms represents the minimum Duration and 24h represents the maximum Duration
+// 0x2c is the UTF-8 hex encoding of comma (,) as the min/max value separator
 func ValidateDuration(fl validator.FieldLevel) bool {
-	_, err := time.ParseDuration(fl.Field().String())
-	return err == nil
+	duration, err := time.ParseDuration(fl.Field().String())
+	if err != nil {
+		return false
+	}
+
+	// if min/max are defined from tag param, check if the duration value is in the duration range
+	param := fl.Param()
+	var min, max time.Duration
+	if param != "" {
+		params := strings.Split(param, CommaSeparator)
+		if len(params) > 0 {
+			min, err = time.ParseDuration(params[0])
+			if err != nil {
+				return false
+			}
+			if duration < min {
+				// the duration value is smaller than the min
+				return false
+			}
+			if len(params) > 1 {
+				max, err = time.ParseDuration(params[1])
+				if err != nil {
+					return false
+				}
+				if duration > max {
+					// the duration value is larger than the max
+					return false
+				}
+			}
+		}
+	}
+	return true
 }
 
 // ValidateDtoUuid used to check the UpdateDTO uuid pointer value

--- a/dtos/autoevent.go
+++ b/dtos/autoevent.go
@@ -10,7 +10,7 @@ import (
 )
 
 type AutoEvent struct {
-	Interval   string `json:"interval" yaml:"interval" validate:"required,edgex-dto-duration"`
+	Interval   string `json:"interval" yaml:"interval" validate:"required,edgex-dto-duration=1ms"` // min/max can be defined as params, ex. edgex-dto-duration=10ms0x2C24h
 	OnChange   bool   `json:"onChange" yaml:"onChange"`
 	SourceName string `json:"sourceName" yaml:"sourceName" validate:"required"`
 }

--- a/dtos/interval.go
+++ b/dtos/interval.go
@@ -15,7 +15,7 @@ type Interval struct {
 	Name        string `json:"name" validate:"edgex-dto-none-empty-string,edgex-dto-rfc3986-unreserved-chars"`
 	Start       string `json:"start,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
 	End         string `json:"end,omitempty" validate:"omitempty,edgex-dto-interval-datetime"`
-	Interval    string `json:"interval" validate:"required,edgex-dto-duration"`
+	Interval    string `json:"interval" validate:"required,edgex-dto-duration=10ms"` // min/max can be defined as params, ex. edgex-dto-duration=10ms0x2C24h
 }
 
 // NewInterval creates interval DTO with required fields


### PR DESCRIPTION
Add min/max params for edgex-dto-duration tag to define the allowed duration range.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/.github/Contributing.md.


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information